### PR TITLE
Google Auth : check google id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ trace
 .env.local
 
 docker-compose.yml
+
+prisma/bann_lg24_google_id.csv

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ docker compose -f ./docker/docker-compose.dev.yaml down
 bunx prisma generate
 bunx prisma migrate dev
 bunx tsx ./prisma/seed.ts
+bunx tsx ./prisma/seed_members.ts # make sure you has baan_lg24_google_id.csv in /prisma folder
 ```
 
 **Note:** You can also run `bunx prisma studio` to open the Prisma Studio to see the database.

--- a/prisma/migrations/20241220134132_add_image_in_account_and_members_table/migration.sql
+++ b/prisma/migrations/20241220134132_add_image_in_account_and_members_table/migration.sql
@@ -1,0 +1,17 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "image" TEXT NOT NULL DEFAULT '';
+
+-- CreateTable
+CREATE TABLE "Members" (
+    "lg_number" TEXT NOT NULL,
+    "prefix" TEXT NOT NULL,
+    "first_name" TEXT NOT NULL,
+    "last_name" TEXT NOT NULL,
+    "nick_name" TEXT NOT NULL,
+    "school" TEXT NOT NULL,
+    "baan" TEXT NOT NULL,
+    "google_id" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Members_lg_number_key" ON "Members"("lg_number");

--- a/prisma/migrations/20241220143236_change_gg_id_to_unique/migration.sql
+++ b/prisma/migrations/20241220143236_change_gg_id_to_unique/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[google_id]` on the table `Members` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "Members_lg_number_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Members_google_id_key" ON "Members"("google_id");

--- a/prisma/migrations/20241222101435_image_to_image_url/migration.sql
+++ b/prisma/migrations/20241222101435_image_to_image_url/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `image` on the `User` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "image",
+ADD COLUMN     "imageUrl" TEXT NOT NULL DEFAULT '';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,12 +51,12 @@ model Session {
 }
 
 model Members {
-  lg_number  String @unique
+  lg_number  String
   prefix     String
   first_name String
   last_name  String
   nick_name  String
   school     String
   baan       String
-  google_id  String
+  google_id  String @unique
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,7 +12,7 @@ model User {
   username   String       @db.VarChar(255)
   baan       Int          @db.Integer
   email      String       @unique @db.VarChar(255)
-  image      String       @default("")
+  imageUrl   String       @default("")
   user_item  User_Item[]
   user_dress User_Dress[]
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,6 +12,7 @@ model User {
   username   String       @db.VarChar(255)
   baan       Int          @db.Integer
   email      String       @unique @db.VarChar(255)
+  image      String       @default("")
   user_item  User_Item[]
   user_dress User_Dress[]
 }
@@ -47,4 +48,15 @@ model User_Dress {
 model Session {
   userId    BigInt @unique
   sessionId String @unique
+}
+
+model Members {
+  lg_number  String @unique
+  prefix     String
+  first_name String
+  last_name  String
+  nick_name  String
+  school     String
+  baan       String
+  google_id  String
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -17,6 +17,7 @@ const mockUserData: Prisma.UserCreateInput[] = [
     email: "john@example.com",
     username: "john",
     baan: 1,
+    image : "john_image"
   },
 ];
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -17,7 +17,7 @@ const mockUserData: Prisma.UserCreateInput[] = [
     email: "john@example.com",
     username: "john",
     baan: 1,
-    image : "john_image"
+    imageUrl : "https://placehold.co/50x50"
   },
 ];
 

--- a/prisma/seed_members.ts
+++ b/prisma/seed_members.ts
@@ -40,7 +40,7 @@ const mockDevMembersData = [
     "nick_name": "นีร",
     "school": "Chula",
     "baan": "555",
-    "google_id": "xxx"
+    "google_id": "xxxx"
   },
 ];
 

--- a/prisma/seed_members.ts
+++ b/prisma/seed_members.ts
@@ -1,0 +1,76 @@
+import fs from 'fs';
+import { PrismaClient} from '@prisma/client';
+
+function csvToMembersData(csv: string) {
+  const rows = csv.trim().split("\n");
+  const headers = rows.shift()?.split(",").map((h) => h.replace(/"/g, ""));
+  if (!headers) return [];
+
+  const membersData = rows.map((row) => {
+    const values = row.split(",").map((v) => v.replace(/"/g, ""));
+    const member: Record<string, string> = {};
+
+    headers.forEach((header, index) => {
+      member[header] = values[index];
+    });
+
+    
+    return {
+      lg_number: member["lg_number"],
+      prefix: member["prefix"],
+      first_name: member["first_name"],
+      last_name: member["last_name"],
+      nick_name: member["nick_name"],
+      school: member["school"],
+      baan: member["baan"],
+      google_id: member["googleId\r"].slice(0, member["googleId\r"].length -1),
+    };
+  });
+
+  return membersData;
+}
+
+
+const mockDevMembersData = [
+  {
+    "lg_number" : "LG_Z00001",
+    "prefix": "นางสาว",
+    "first_name": "ณภัทร",
+    "last_name": "เสรีรักษ์",
+    "nick_name": "นีร",
+    "school": "Chula",
+    "baan": "555",
+    "google_id": "xxx"
+  },
+];
+
+const prisma = new PrismaClient();
+async function main() {
+  // gem Nong's data
+  const filePath = './prisma/bann_lg24_google_id.csv';
+  const csvInput = fs.readFileSync(filePath, 'utf8');
+  const mockMembersData = csvToMembersData(csvInput);
+  
+  console.log("Start seeding...");
+  const userMembers = await prisma.members.createMany({
+    data: mockMembersData,
+  });
+  console.log("Created members: ", userMembers);
+
+  // gen Dev Data
+  // console.log("Start seeding...");
+  // const userMembers = await prisma.members.createMany({
+  //   data: mockDevMembersData,
+  // });
+  // console.log("Created members: ", userMembers);
+}
+
+main()
+  .then(async (res) => {
+    await prisma.$disconnect();
+  })
+  .catch(async (err) => {
+    console.log(err);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -3,7 +3,6 @@ import { Elysia, t } from "elysia";
 export const authModel = new Elysia().model({
   signInBody: t.Object({
     id: t.String(),
-    name: t.String(),
     email: t.String(),
     image: t.String(),
   }),

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -6,7 +6,7 @@ import { authModel } from "@/models/auth";
 
 export const authService = new Elysia({ prefix: "/auth" }).use(authModel).post(
   "/sign-in",
-  async ({ body, set }) => {
+  async ({ body, set }) => {    
     try {
       const user = await prisma.user.findUnique({
         where: {

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -26,10 +26,21 @@ export const authService = new Elysia({ prefix: "/auth" }).use(authModel).post(
         }
 
         // TODO: FETCH BAAN FROM SOMEWHERE & VALIDATE USER ROLE
+        const memberInfo = await prisma.members.findUnique({
+          where : {
+            google_id : body.id,
+          }
+        })
+
+        if(!memberInfo){
+          set.status = "Conflict";
+          return { message: "Google Account not allow" };
+        }
+
         const createdUser = await prisma.user.create({
           data: {
             username: body.name,
-            baan: 999,
+            baan: parseInt(memberInfo.baan),
             email: body.email,
             image : body.image,
           },

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -31,6 +31,7 @@ export const authService = new Elysia({ prefix: "/auth" }).use(authModel).post(
             username: body.name,
             baan: 999,
             email: body.email,
+            image : body.image,
           },
         });
 

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -7,7 +7,7 @@ import { authModel } from "@/models/auth";
 export const authService = new Elysia({ prefix: "/auth" }).use(authModel).post(
   "/sign-in",
   async ({ body, set }) => {    
-    try {
+    try {      
       const user = await prisma.user.findUnique({
         where: {
           email: body.email,
@@ -31,6 +31,7 @@ export const authService = new Elysia({ prefix: "/auth" }).use(authModel).post(
             google_id : body.id,
           }
         })
+        
 
         if(!memberInfo){
           set.status = "Conflict";
@@ -39,7 +40,7 @@ export const authService = new Elysia({ prefix: "/auth" }).use(authModel).post(
 
         const createdUser = await prisma.user.create({
           data: {
-            username: body.name,
+            username: `${memberInfo.first_name} ${memberInfo.last_name}`,
             baan: parseInt(memberInfo.baan),
             email: body.email,
             image : body.image,

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -25,7 +25,6 @@ export const authService = new Elysia({ prefix: "/auth" }).use(authModel).post(
           return { message: "Session ID Already Exists" };
         }
 
-        // TODO: FETCH BAAN FROM SOMEWHERE & VALIDATE USER ROLE
         const memberInfo = await prisma.members.findUnique({
           where : {
             google_id : body.id,

--- a/src/modules/profile.ts
+++ b/src/modules/profile.ts
@@ -48,6 +48,7 @@ export const profileService = new Elysia({ prefix: "/user" })
       user_id: user?.user_id.toString(),
       username: user?.username,
       baan: user?.baan.toString(),
+      image: user?.image,
       email: user?.email,
       dresses: dress_user_id,
       items: item_user_id,


### PR DESCRIPTION
- change/add prisma schema
	- add new table "Members" : data of nongs(น้อง) in larngear
	- add new field "image" in User : to store nong's profile picture url
- add larngear Members information to prisma by `bunx tsx ./prisma/seed_members.ts`
	- `bunx tsx ./prisma/seed_members.ts` will add data in `bann_lg24_google_id.csv` to database (this file is private. I will not add it to github)
	- IMPORTANT : ** if you want to login, please add your own gmail in mockDevMembersData, set google_id = google_sub. get that google_sub by uncomment log profile in frontend\src\server\auth\config.ts **
	- each nong's will has google_id to verify gmail when signup
- change sign-in process
	- it will only use id, image params
	- when signup, we will check google_id if it match nong's googlei in Members table
	- add profile-url in prisma create user 'image' field
	- baan will be real baan lawe
	- IMPORTANT : ** BUT, in dev I will comment check google_id part, in production please delete this comment **
- change GET /user : responds data will has 'image' too
- change type UserCreateInput  : make image not optional
- change seed.ts : add image for mr.john (mock data)